### PR TITLE
feat(list): allow configuring available style types

### DIFF
--- a/packages/ckeditor5-list/src/listconfig.ts
+++ b/packages/ckeditor5-list/src/listconfig.ts
@@ -180,12 +180,36 @@ export interface ListPropertiesStyleConfig {
 	 * {@link module:list/listproperties~ListProperties list properties}.
 	 *
 	 * @default false
-	 */
-	useAttribute?: boolean;
+        */
+        useAttribute?: boolean;
 
-	/**
-	 * Defines which list styles should be available in the UI.
-	 * Accepts a configuration object with numbered and bulleted styles.
+        /**
+        * Defines which list style types should be available in the UI.
+        * Accepts an array of style names that will be enabled for both bulleted and numbered lists.
+        *
+        * ```ts
+        * {
+        *   list: {
+        *     properties: {
+        *       styles: {
+        *         styleTypes: [ 'disc', 'decimal' ]
+        *       }
+        *     }
+        *   }
+        * }
+        * ```
+        *
+        * **Note**: If {@link ~ListPropertiesStyleConfig#listTypes `listTypes`} are configured, the resulting
+        * available styles will be additionally limited to the enabled list types.
+        *
+        * **Note**: This configuration works only with
+        * {@link module:list/listproperties~ListProperties list properties}.
+        */
+        styleTypes?: ArrayOrItem<string>;
+
+        /**
+         * Defines which list styles should be available in the UI.
+         * Accepts a configuration object with numbered and bulleted styles.
 	 *
 	 * ```ts
 	 * {
@@ -231,7 +255,7 @@ export interface ListPropertiesStyleConfig {
 	 *   bulleted: [ 'disc', 'circle', 'square' ]
 	 * }`
 	 */
-	listStyleTypes?: ListStyleTypesConfig;
+        listStyleTypes?: ListStyleTypesConfig;
 }
 
 export interface ListStyleTypesConfig {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -273,7 +273,9 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 	const normalizedConfig = getNormalizedConfig( enabledProperties );
 
 	if ( enabledProperties.styles ) {
-		const useAttribute = normalizedConfig.styles.useAttribute;
+                const useAttribute = normalizedConfig.styles.useAttribute;
+                const configuredStyleTypes = normalizedConfig.styles.listStyleTypes;
+                const flatStyleTypes = normalizedConfig.styles.styleTypes;
 
 		strategies.push( {
 			attributeName: 'listStyle',
@@ -281,14 +283,28 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 			viewConsumables: { styles: 'list-style-type' },
 
 			addCommand( editor ) {
-				let supportedTypes = getAllSupportedStyleTypes();
+                                let supportedTypes = getAllSupportedStyleTypes();
 
-				if ( useAttribute ) {
-					supportedTypes = supportedTypes.filter( styleType => !!getTypeAttributeFromListStyleType( styleType ) );
-				}
+                                if ( useAttribute ) {
+                                        supportedTypes = supportedTypes.filter( styleType => !!getTypeAttributeFromListStyleType( styleType ) );
+                                }
 
-				editor.commands.add( 'listStyle', new ListStyleCommand( editor, DEFAULT_LIST_TYPE, supportedTypes ) );
-			},
+                                if ( configuredStyleTypes ) {
+                                        const allowed = new Set( [
+                                                ...( configuredStyleTypes.numbered || [] ),
+                                                ...( configuredStyleTypes.bulleted || [] )
+                                        ] );
+
+                                        supportedTypes = supportedTypes.filter( styleType => allowed.has( styleType ) );
+                                }
+                                else if ( flatStyleTypes ) {
+                                        const allowed = new Set( flatStyleTypes );
+
+                                        supportedTypes = supportedTypes.filter( styleType => allowed.has( styleType ) );
+                                }
+
+                                editor.commands.add( 'listStyle', new ListStyleCommand( editor, DEFAULT_LIST_TYPE, supportedTypes ) );
+                        },
 
 			appliesToListItem( item ) {
 				return item.getAttribute( 'listType' ) == 'numbered' || item.getAttribute( 'listType' ) == 'bulleted';

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -375,16 +375,20 @@ function createListPropertiesView( {
 			listStyleCommand
 		} );
 
-		const configuredListStylesTypes = normalizedConfig.styles.listStyleTypes;
-		let filteredDefinitions = styleDefinitions;
+                const configuredListStylesTypes = normalizedConfig.styles.listStyleTypes;
+                const flatStyleTypes = normalizedConfig.styles.styleTypes;
+                let filteredDefinitions = styleDefinitions;
 
-		if ( configuredListStylesTypes ) {
-			const allowedTypes = configuredListStylesTypes[ listType ];
+                if ( configuredListStylesTypes ) {
+                        const allowedTypes = configuredListStylesTypes[ listType ];
 
-			if ( allowedTypes ) {
-				filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
-			}
-		}
+                        if ( allowedTypes ) {
+                                filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
+                        }
+                }
+                else if ( flatStyleTypes ) {
+                        filteredDefinitions = styleDefinitions.filter( def => flatStyleTypes.includes( def.type ) );
+                }
 
 		const isStyleTypeSupported = getStyleTypeSupportChecker( listStyleCommand );
 		styleButtonViews = filteredDefinitions
@@ -468,17 +472,21 @@ function getMenuBarStylesMenuCreator(
 			listStyleCommand
 		} );
 
-		const configuredListStylesTypes = normalizedConfig.styles.listStyleTypes;
-		let filteredDefinitions = styleDefinitions;
+                const configuredListStylesTypes = normalizedConfig.styles.listStyleTypes;
+                const flatStyleTypes = normalizedConfig.styles.styleTypes;
+                let filteredDefinitions = styleDefinitions;
 
-		if ( configuredListStylesTypes ) {
-			const listType = listCommand.type as 'numbered' | 'bulleted';
-			const allowedTypes = configuredListStylesTypes[ listType ];
+                if ( configuredListStylesTypes ) {
+                        const listType = listCommand.type as 'numbered' | 'bulleted';
+                        const allowedTypes = configuredListStylesTypes[ listType ];
 
-			if ( allowedTypes ) {
-				filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
-			}
-		}
+                        if ( allowedTypes ) {
+                                filteredDefinitions = styleDefinitions.filter( def => allowedTypes.includes( def.type ) );
+                        }
+                }
+                else if ( flatStyleTypes ) {
+                        filteredDefinitions = styleDefinitions.filter( def => flatStyleTypes.includes( def.type ) );
+                }
 
 		const styleButtonViews = filteredDefinitions.filter( isStyleTypeSupported ).map( styleButtonCreator );
 		const listPropertiesView = new ListPropertiesView( locale, {

--- a/packages/ckeditor5-list/src/listproperties/utils/config.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/config.ts
@@ -54,10 +54,10 @@ export function getNormalizedConfig( config: ListPropertiesConfig ): NormalizedL
  * @returns An object with normalized list properties styles.
  */
 function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): NormalizedListPropertiesConfig[ 'styles' ] {
-	const normalizedConfig: NormalizedListPropertiesConfig[ 'styles' ] = {
-		listTypes: [ 'bulleted', 'numbered' ],
-		useAttribute: false
-	};
+        const normalizedConfig: NormalizedListPropertiesConfig[ 'styles' ] = {
+                listTypes: [ 'bulleted', 'numbered' ],
+                useAttribute: false
+        };
 
 	if ( styles === true ) {
 		return normalizedConfig;
@@ -69,17 +69,20 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 	else if ( Array.isArray( styles ) || typeof styles == 'string' ) {
 		normalizedConfig.listTypes = toArray( styles );
 	}
-	else {
-		normalizedConfig.listTypes = styles.listTypes ?
-			toArray( styles.listTypes ) :
-			normalizedConfig.listTypes;
+        else {
+                normalizedConfig.listTypes = styles.listTypes ?
+                        toArray( styles.listTypes ) :
+                        normalizedConfig.listTypes;
 
-		normalizedConfig.useAttribute = !!styles.useAttribute;
+                normalizedConfig.useAttribute = !!styles.useAttribute;
 
-		if ( styles.listStyleTypes ) {
-			normalizedConfig.listStyleTypes = styles.listStyleTypes;
-		}
-	}
+                if ( styles.styleTypes ) {
+                        normalizedConfig.styleTypes = toArray( styles.styleTypes );
+                }
+                else if ( styles.listStyleTypes ) {
+                        normalizedConfig.listStyleTypes = styles.listStyleTypes;
+                }
+        }
 
 	return normalizedConfig;
 }
@@ -90,14 +93,15 @@ function getNormalizedStylesConfig( styles: ListPropertiesConfig[ 'styles' ] ): 
 * @internal
 */
 export type NormalizedListPropertiesConfig = {
-	styles: {
-		listTypes: Array<ListPropertiesStyleListType>;
-		listStyleTypes?: {
-			numbered?: Array<string>;
-			bulleted?: Array<string>;
-		};
-		useAttribute: boolean;
-	};
-	startIndex: boolean;
-	reversed: boolean;
+        styles: {
+                listTypes: Array<ListPropertiesStyleListType>;
+                styleTypes?: Array<string>;
+                listStyleTypes?: {
+                        numbered?: Array<string>;
+                        bulleted?: Array<string>;
+                };
+                useAttribute: boolean;
+        };
+        startIndex: boolean;
+        reversed: boolean;
 };

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
@@ -72,9 +72,9 @@ describe( 'ListPropertiesEditing', () => {
 			return editor.destroy();
 		} );
 
-		describe( 'command', () => {
-			it( 'should register `listStyle` command with support for all style types', () => {
-				const command = editor.commands.get( 'listStyle' );
+                describe( 'command', () => {
+                        it( 'should register `listStyle` command with support for all style types', () => {
+                                const command = editor.commands.get( 'listStyle' );
 
 				expect( command.isStyleTypeSupported( 'disc' ) ).to.be.true;
 				expect( command.isStyleTypeSupported( 'circle' ) ).to.be.true;
@@ -86,9 +86,31 @@ describe( 'ListPropertiesEditing', () => {
 				expect( command.isStyleTypeSupported( 'lower-alpha' ) ).to.be.true;
 				expect( command.isStyleTypeSupported( 'upper-alpha' ) ).to.be.true;
 				expect( command.isStyleTypeSupported( 'lower-latin' ) ).to.be.true;
-				expect( command.isStyleTypeSupported( 'upper-latin' ) ).to.be.true;
-			} );
-		} );
+                                expect( command.isStyleTypeSupported( 'upper-latin' ) ).to.be.true;
+                        } );
+
+                        it( 'should respect the styleTypes configuration', async () => {
+                                const customEditor = await VirtualTestEditor.create( {
+                                        plugins: [ Paragraph, ListPropertiesEditing, UndoEditing ],
+                                        list: {
+                                                properties: {
+                                                        styles: { styleTypes: [ 'disc', 'decimal' ] },
+                                                        startIndex: false,
+                                                        reversed: false
+                                                }
+                                        }
+                                } );
+
+                                const command = customEditor.commands.get( 'listStyle' );
+
+                                expect( command.isStyleTypeSupported( 'disc' ) ).to.be.true;
+                                expect( command.isStyleTypeSupported( 'decimal' ) ).to.be.true;
+                                expect( command.isStyleTypeSupported( 'circle' ) ).to.be.false;
+                                expect( command.isStyleTypeSupported( 'lower-roman' ) ).to.be.false;
+
+                                await customEditor.destroy();
+                        } );
+                } );
 
 		describe( 'schema rules', () => {
 			it( 'should allow set `listStyle` on the `paragraph`', () => {

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -256,8 +256,8 @@ describe( 'ListPropertiesUI', () => {
 					} );
 				} );
 
-				describe( 'listStyleTypes config entry', () => {
-					it( 'should register buttons filtered by listStyleTypes for bulleted list', () => {
+                                describe( 'listStyleTypes config entry', () => {
+                                        it( 'should register buttons filtered by listStyleTypes for bulleted list', () => {
 						return withEditor( {
 							styles: {
 								listStyleTypes: {
@@ -339,9 +339,9 @@ describe( 'ListPropertiesUI', () => {
 
 							numberedListDropdown.element.remove();
 						} );
-					} );
+                                        } );
 
-					it( 'should register no buttons when listStyleTypes has empty array', () => {
+                                        it( 'should register no buttons when listStyleTypes has empty array', () => {
 						return withEditor( {
 							styles: {
 								listStyleTypes: {
@@ -365,9 +365,59 @@ describe( 'ListPropertiesUI', () => {
 							expect( listPropertiesView.stylesView ).to.be.null;
 
 							numberedListDropdown.element.remove();
-						} );
-					} );
-				} );
+                                                } );
+                                        } );
+                                } );
+
+                                describe( 'styleTypes config entry', () => {
+                                        it( 'should register buttons filtered by styleTypes for bulleted list', () => {
+                                                return withEditor( {
+                                                        styles: {
+                                                                styleTypes: [ 'disc', 'circle' ]
+                                                        }
+                                                }, editor => {
+                                                        const componentFactory = editor.ui.componentFactory;
+                                                        const bulletedListDropdown = componentFactory.create( 'bulletedList' );
+
+                                                        bulletedListDropdown.render();
+                                                        document.body.appendChild( bulletedListDropdown.element );
+
+                                                        bulletedListDropdown.isOpen = true;
+                                                        bulletedListDropdown.isOpen = false;
+
+                                                        const listPropertiesView = bulletedListDropdown.panelView.children.first;
+                                                        const stylesView = listPropertiesView.stylesView;
+
+                                                        expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Disc', 'Circle' ] );
+
+                                                        bulletedListDropdown.element.remove();
+                                                } );
+                                        } );
+
+                                        it( 'should register buttons filtered by styleTypes for numbered list', () => {
+                                                return withEditor( {
+                                                        styles: {
+                                                                styleTypes: [ 'decimal', 'lower-roman' ]
+                                                        }
+                                                }, editor => {
+                                                        const componentFactory = editor.ui.componentFactory;
+                                                        const numberedListDropdown = componentFactory.create( 'numberedList' );
+
+                                                        numberedListDropdown.render();
+                                                        document.body.appendChild( numberedListDropdown.element );
+
+                                                        numberedListDropdown.isOpen = true;
+                                                        numberedListDropdown.isOpen = false;
+
+                                                        const listPropertiesView = numberedListDropdown.panelView.children.first;
+                                                        const stylesView = listPropertiesView.stylesView;
+
+                                                        expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Decimal', 'Lower–roman' ] );
+
+                                                        numberedListDropdown.element.remove();
+                                                } );
+                                        } );
+                                } );
 			} );
 
 			describe( 'bulleted list dropdown', () => {
@@ -1271,7 +1321,7 @@ describe( 'ListPropertiesUI', () => {
 						} );
 					} );
 
-					it( 'should register no buttons when listStyleTypes has empty array in menu bar', () => {
+                                        it( 'should register no buttons when listStyleTypes has empty array in menu bar', () => {
 						return withEditor( {
 							styles: {
 								listStyleTypes: {
@@ -1295,9 +1345,59 @@ describe( 'ListPropertiesUI', () => {
 							expect( listPropertiesView.stylesView ).to.be.null;
 
 							numberedListMenu.element.remove();
-						} );
-					} );
-				} );
+                                                } );
+                                        } );
+                                } );
+
+                                describe( 'styleTypes config entry', () => {
+                                        it( 'should register buttons filtered by styleTypes for bulleted list in menu bar', () => {
+                                                return withEditor( {
+                                                        styles: {
+                                                                styleTypes: [ 'disc', 'circle' ]
+                                                        }
+                                                }, editor => {
+                                                        const componentFactory = editor.ui.componentFactory;
+                                                        const bulletedListMenu = componentFactory.create( 'menuBar:bulletedList' );
+
+                                                        bulletedListMenu.render();
+                                                        document.body.appendChild( bulletedListMenu.element );
+
+                                                        bulletedListMenu.isOpen = true;
+                                                        bulletedListMenu.isOpen = false;
+
+                                                        const listPropertiesView = bulletedListMenu.panelView.children.first;
+                                                        const stylesView = listPropertiesView.stylesView;
+
+                                                        expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Disc', 'Circle' ] );
+
+                                                        bulletedListMenu.element.remove();
+                                                } );
+                                        } );
+
+                                        it( 'should register buttons filtered by styleTypes for numbered list in menu bar', () => {
+                                                return withEditor( {
+                                                        styles: {
+                                                                styleTypes: [ 'decimal', 'lower-roman' ]
+                                                        }
+                                                }, editor => {
+                                                        const componentFactory = editor.ui.componentFactory;
+                                                        const numberedListMenu = componentFactory.create( 'menuBar:numberedList' );
+
+                                                        numberedListMenu.render();
+                                                        document.body.appendChild( numberedListMenu.element );
+
+                                                        numberedListMenu.isOpen = true;
+                                                        numberedListMenu.isOpen = false;
+
+                                                        const listPropertiesView = numberedListMenu.panelView.children.first;
+                                                        const stylesView = listPropertiesView.stylesView;
+
+                                                        expect( stylesView.children.map( b => b.tooltip ) ).to.deep.equal( [ 'Decimal', 'Lower–roman' ] );
+
+                                                        numberedListMenu.element.remove();
+                                                } );
+                                        } );
+                                } );
 			} );
 
 			describe( 'bulleted list menu', () => {


### PR DESCRIPTION
## Summary
- add `styleTypes` option to list properties configuration
- limit list style command and UI to configured style types
- cover styleTypes filtering with tests

## Testing
- `yarn test packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js packages/ckeditor5-list/tests/listproperties/listpropertiesui.js` *(fails: Cannot find module '@ckeditor/ckeditor5-dev-tests/bin/testautomated.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a826a3563483309c805a8ed2d9b6dc